### PR TITLE
Bugfix mineral composition calculation

### DIFF
--- a/src/_mineral_composition.py
+++ b/src/_mineral_composition.py
@@ -531,7 +531,7 @@ def _oxides_content_in_bm(
     )
 
     # Equations giving the FeO and AlO2 content in Bm
-    c_1 = 0.5 * self.m_al2o3 / (al * (feo / self.m_feo - x_feo_fp * x_m_fp / m_fp))
+    c_1 = 0.5 * self.m_al2o3 / al * (feo / self.m_feo - x_feo_fp * x_m_fp / m_fp)
     x_alo2_bm = self.kd_ref_am * x_feo_fp / (
         2 * c_1 * (1 - x_feo_fp) + self.kd_ref_am * x_feo_fp +
         self.kd_ref_am * x_feo_fp * (2 - ratio_fe) * c_1

--- a/src/_mineral_composition.py
+++ b/src/_mineral_composition.py
@@ -238,6 +238,9 @@ def _solve_mineral_composition(
     else:
         al_excess = False
 
+    # Converting density
+    rho_capv = rho_capv / 5500
+
     if (p_fp > 0.0):
         ### Ferropericlase is present in the rock assemblage ###
         # Setting lower bound and upper bound for the solution

--- a/src/_spin_configuration.py
+++ b/src/_spin_configuration.py
@@ -66,7 +66,7 @@ def _calc_spin_configuration(self):
     delta_x = 0.01
     self.x_vec = np.arange(x_min, x_max + delta_x, delta_x)
     self.T_vec = self.T_am + np.arange(
-        self.dT_min, self.dT_max + self.delta_dT, self.delta_dT
+        0.0, self.dT_max + self.delta_dT, self.delta_dT
     )
 
     # Calculating range for the volume of Fp using extreme cases
@@ -82,13 +82,13 @@ def _calc_spin_configuration(self):
     v_max = solution[0] / 0.15055
 
     n_T = len(self.T_vec)
-    n_v = round((v_max - v_min) / self.delta_v)
+    n_v = round((v_max - v_min) / self.delta_v) + 1
     n_x = len(self.x_vec)
 
     # Initializing
     spin_config = np.zeros((n_T, n_v, n_x))
     P_table = np.zeros((n_T, n_v, n_x))
-    k_b = 8.617**(-5) # Boltzmann constant
+    k_b = 8.617 * 10**(-5) # Boltzmann constant
     v_fp_0 = self.v_feo_hs_0 / 0.15055
 
     # The energy degeneracy of the electronic configuration for the low/high


### PR DESCRIPTION
# Description
- Fixed calculation of c_1 in the system of equation
- Fixed issue that the density of CaPv was not properly rescaled
- Fixed calculation of the spin configuration

# Note
The calculation is still not working properly.
This is because the solver is not able to find the proper solution.
The solver will be improve in the next PR.