### PR TITLE
Add main utilities for seismic properties calculation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -33,6 +33,7 @@ Copyright, 2023,  Vilella Kenny.
 import os
 from _spin_configuration import _calc_spin_configuration
 from _mineral_composition import _calc_mineral_composition
+from _seismic_properties import _calc_seismic_properties
 #======================================================================================#
 #                                                                                      #
 #                    Starting implementation of the simulator class                    #
@@ -111,6 +112,43 @@ class MineralProperties:
         v_al2o3_0: Volume of Al2O3 at ambient conditions. Default to 26.74. [cm^3/mol]
         k_casio3_0: Bulk modulus of CaSiO3 at ambient conditions. Default to 236. [GPa]
         v_casio3_0: Volume of CaSiO3 at ambient conditions. Default to 27.45. [cm^3/mol]
+        g_mgo_0: Shear modulus of MgO at ambient conditions. Default to 131. [GPa]
+        g_prime_mgo: Pressure derivative of the shear modulus for MgO. Default to 1.92.
+        g_feo_hs_0: Shear modulus of FeO in the high spin state at ambient conditions.
+                    Default to 29.9. [GPa]
+        g_prime_feo_hs: Pressure derivative of the shear modulus for FeO in the high
+                        spin state. Default to 6.26.
+        g_feo_ls_0: Shear modulus of FeO in the low spin state at ambient conditions.
+                    Default to 119. [GPa]
+        g_prime_feo_ls: Pressure derivative of the shear modulus for FeO in the high
+                        spin state. Default to 3.9.
+        g_casio3_0: Shear modulus of CaSiO3 at ambient conditions. Default to 135. [GPa]
+        g_prime_casio3: Pressure derivative of the shear modulus for CaSiO3.
+                      Default to 1.57.
+        g_mgsio3_0: Shear modulus of MgSiO3 at ambient conditions.
+                    Default to 168.2. [GPa]
+        g_prime_mgsio3: Pressure derivative of the shear modulus for MgSiO3.
+                        Default to 1.79.
+        g_fesio3_0: Shear modulus of FeSiO3 at ambient conditions.
+                    Default to 145.7. [GPa]
+        g_prime_fesio3: Pressure derivative of the shear modulus for FeSiO3.
+                        Default to 1.87.
+        g_fealo3_0: Shear modulus of FeAlO3 at ambient conditions.
+                    Default to 95.3. [GPa]
+        g_prime_fealo3: Pressure derivative of the shear modulus for FeAlO3.
+                        Default to 2.13.
+        g_fe2o3_0: Shear modulus of Fe2O3 at ambient conditions. Default to 53.2. [GPa]
+        g_prime_fe2o3: Pressure derivative of the shear modulus for Fe2O3.
+                       Default to 2.63.
+        g_al2o3_0: Shear modulus of Al2O3 at ambient conditions. Default to 129.2. [GPa]
+        g_prime_al2o3: Pressure derivative of the shear modulus for Al2O3.
+                       Default to 2.32.
+        g_dot_bm: Temperature derivative of the shear modulus for Bm.
+                  Default to -0.02. [GPa/K]
+        g_dot_fp: Temperature derivative of the shear modulus for Fp.
+                  Default to -0.02. [GPa/K]
+        g_dot_capv: Temperature derivative of the shear modulus for CaPv.
+                    Default to -0.002. [GPa/K]
         m_mgo: Molar mass of MgO. [g/mol]
         m_feo: Molar mass of FeO. [g/mol]
         m_mgsio3: Molar mass of MgSiO3. [g/mol]
@@ -235,6 +273,31 @@ class MineralProperties:
         self.k_casio3_0 = prop.get("k_casio3_0", 236.) # Shin 2000
         self.v_casio3_0 = prop.get("v_casio3_0", 27.45) # Shin 2000
 
+        # Shear modulus parameters for various components
+        self.g_mgo_0 = prop.get("g_mgo_0", 131.) # Murakami 2009
+        self.g_prime_mgo = prop.get("g_prime_mgo", 1.92) # Murakami 2009
+        self.g_feo_hs_0 = prop.get("g_feo_hs_0", 29.9) # Murakami 2012
+        self.g_prime_feo_hs = prop.get("g_prime_feo_hs", 6.26) # Murakami 2012
+        self.g_feo_ls_0 = prop.get("g_feo_ls_0", 119.) # Murakami 2012
+        self.g_prime_feo_ls = prop.get("g_prime_feo_ls", 3.90) # Murakami 2012
+        self.g_casio3_0 = prop.get("g_casio3_0", 135.) # Li 2006
+        self.g_prime_casio3 = prop.get("g_prime_casio3", 1.57) # Li 2006
+        self.g_mgsio3_0 = prop.get("g_mgsio3_0", 168.2) # Shukla 2015
+        self.g_prime_mgsio3 = prop.get("g_prime_mgsio3", 1.79) # Shukla 2015
+        self.g_fesio3_0 = prop.get("g_fesio3_0", 145.7) # Shukla 2015
+        self.g_prime_fesio3 = prop.get("g_prime_fesio3", 1.87) # Shukla 2015
+        self.g_fealo3_0 = prop.get("g_fealo3_0", 95.3) # Shukla 2016
+        self.g_prime_fealo3 = prop.get("g_prime_fealo3", 2.13) # Shukla 2016
+        self.g_fe2o3_0 = prop.get("g_fe2o3_0", 53.2) # Shukla 2016
+        self.g_prime_fe2o3 = prop.get("g_prime_fe2o3", 2.63) # Shukla 2016
+        self.g_al2o3_0 = prop.get("g_al2o3_0", 129.2) # Shukla 2016
+        self.g_prime_al2o3 = prop.get("g_prime_al2o3", 2.32) # Shukla 2016
+
+        # Temperature derivative of the shear modulus
+        self.g_dot_bm = prop.get("g_dot_bm", -0.02) # Murakami 2012
+        self.g_dot_fp = prop.get("g_dot_fp", -0.02) # Murakami 2012
+        self.g_dot_capv = prop.get("g_dot_capv", -0.002) # Li 2006
+
         # Molar masses for various components
         self.m_mgo = 40.304
         self.m_feo = 71.844
@@ -303,3 +366,6 @@ class MineralProperties:
 
         # Calculating the mineral compositions
         _calc_mineral_composition(self, spin_config, P_table)
+
+        # Calculating the seismic properties
+        _calc_seismic_properties(self, spin_config, P_table)

--- a/src/_eos_implementation.py
+++ b/src/_eos_implementation.py
@@ -11,7 +11,8 @@ properties.
 
 These functions are mainly derived from the Mie-Gruneisen-Debye equation of state (EOS).
 A thorough description of this EOS can be found in Jackson and Rigden (1996) and in the
-supplementary material of Vilella et al. (2021).
+supplementary material of Vilella et al. (2021). The shear modulus calculation follows
+the model presented in Bina and Helffrich (1992).
 
 These functions should not be used outside the class MineralProperties.
 
@@ -35,13 +36,14 @@ class _EOS(ABC):
     """Provides base utilities to implement the Mie-Gruneisen-Debye equation of state.
 
     This class provides the basic functionality required to implement the
-    Mie-Gruneisen-Debye equation of state.
+    Mie-Gruneisen-Debye equation of state and to calculate the shear modulus.
 
     The abstract methods are then applied to each mineral in their corresponding derived
     class.
 
     The formalism for the Mie-Gruneisen-Debye equation of state used in this class can
-    be found in Jackson and Rigden (1996).
+    be found in Jackson and Rigden (1996), while the shear modulus calculation can be
+    found in Bina and Helffrich (1992).
     """
     @abstractmethod
     def _gamma(self, gamma_0, v_ratio, q):
@@ -122,6 +124,45 @@ class _EOS(ABC):
         return 9. * n * R * T**4 / theta**3 * int_part
 
     @abstractmethod
+    def _E_th_dv(self, n, R, T, theta, gamma, v, E_th, E_th_0):
+        """
+        """
+        d_int_part = 9 * n * R * (
+            1 / (np.exp(theta / T) - 1) - 1 / (np.exp(theta / 300) - 1)
+        )
+        return (gamma * theta / v) * (3 * (E_th - E_th_0) / theta - d_int_part)
+
+    @abstractmethod
+    def _E_th_dT(self, n, R, T, theta, E_th):
+        """
+        """
+        return 4 * E_th / T - 9 * n * R * (theta / T) / (np.exp(theta / T) - 1)
+
+    def _integral_vibrational_energy(self, x_max):
+        """Calculates the integral part of the vibrational energy.
+
+        It corresponds to the eq. (30) of Jackson and Rigden (1996).
+
+        Args:
+            x_max: Value for the upper bound of the integral.
+
+        Returns:
+            Float64: Value of the integral.
+        """
+        value, err = scipy.integrate.quad(
+            lambda x: x**3 / (np.exp(x) - 1), 0, x_max
+        )
+        return value
+
+    @abstractmethod
+    def _alpha(self, k_0, gamma, q, v, E_th, E_th_0, E_th_dv, E_th_dT):
+        """
+        """
+        return gamma / v * E_th_dT / (
+            k_0 - (q - 1) * gamma * (E_th - E_th_0) / v - gamma * E_th_dv
+        )
+
+    @abstractmethod
     def _MGD(self, BM3, gamma, v, E_th, E_th_0):
         """Calculates the Mie-Gruneisen-Debye equation of state.
 
@@ -140,21 +181,29 @@ class _EOS(ABC):
         """
         return BM3  - gamma / v * (E_th - E_th_0)
 
-    def _integral_vibrational_energy(self, x_max):
-        """Calculates the integral part of the vibrational energy.
-
-        It corresponds to the eq. (30) of Jackson and Rigden (1996).
-
-        Args:
-            x_max: Value for the upper bound of the integral.
-
-        Returns:
-            Float64: Value of the integral.
+    @abstractmethod
+    def _g_t0(self, g_0, g_prime, k_0, v_ratio):
         """
-        value, err = scipy.integrate.quad(
-            lambda x: x**3 / (np.exp(x) - 1), 0, x_max
+        """
+        return v_ratio**(5/3) * (
+            g_0 + (1 - v_ratio**(2/3)) * 0.5 * (5 * g_0 - 3 * k_0 * g_prime)
         )
-        return value
+
+    @abstractmethod
+    def _k_s(
+        self, T, k_0, k0t_prime, gamma, q, alpha, v, v_ratio, E_th, E_th_0, E_th_dv
+    ):
+        """
+        """
+        # Bulk modulus at ambient temperature and considered pressure/volume
+        k_v = k_0 * (
+            (v_ratio**(7/3) - v_ratio**(5/3)) * 3/4 * (k0t_prime - 4) * v_ratio**(2/3) +
+            0.5 * (7 * v_ratio**(7/3) - 5 * v_ratio**(5/3)) *
+            (1 + 3/4 * (k0t_prime - 4) * (v_ratio**(2/3) - 1))
+        )
+        # Bulk modulus at considered temperature/pressure/volume
+        k_t = k_v - (q - 1) * gamma / v * (E_th - E_th_0) - gamma * E_th_dv
+        return k_t * (1 + alpha * gamma * T)
 
 #======================================================================================#
 #                                                                                      #
@@ -168,7 +217,8 @@ class _EOS_fp(_EOS):
     functionality required to implement the Mie-Gruneisen-Debye equation of state.
 
     The formalism for the Mie-Gruneisen-Debye equation of state used in this class can
-    be found in Jackson and Rigden (1996).
+    be found in Jackson and Rigden (1996), while the shear modulus calculation can be
+    found in Bina and Helffrich (1992).
 
     This class should not be used outside the class MineralProperties.
     """
@@ -198,13 +248,13 @@ class _EOS_fp(_EOS):
         v_feo_0 = self. _v_feo_0(data, eta_ls)
         return x_fp * v_feo_0 + (1 - x_fp) * data.v_mgo_0
 
-    def _k_VRH_average(self, x_1, v_1, k_1, v_2, k_2):
-        """Calculates the Voigt-Reuss-Hill average of the bulk modulus.
+    def _VRH_average(self, x_1, v_1, c_1, v_2, c_2):
+        """Calculates the Voigt-Reuss-Hill average.
 
         Implement the Voigt-Reuss-Hill average for a mixture of two components. This is
         traditionally used to calculate the elasticity of polycrystal from the
         elasticity of its individual components. Here, it is used to calculate the bulk
-        modulus of Ferropericlase.
+        modulus or shear modulus of Ferropericlase.
 
         Note that the volume can be given in any unit as long as the two volumes are
         given in the same unit.
@@ -212,18 +262,18 @@ class _EOS_fp(_EOS):
         Args:
             x_1: Molar concentraion of the first component.
             v_1: Volume of the first component.
-            k_1: Bulk modulus of the first component. [GPa]
+            c_1: Bulk or shear modulus of the first component. [GPa]
             v_2: Volume of the second component.
-            k_2: Bulk modulus of the second component. [GPa]
+            c_2: Bulk or shear modulus of the second component. [GPa]
 
         Returns:
-            Float64: Voigt-Reuss-Hill average of the bulk modulus. [GPa]
+            Float64: Voigt-Reuss-Hill average of the bulk or shear modulus. [GPa]
         """
         x_2 = 1 - x_1
         v_tot = x_1 * v_1 + x_2 * v_2
-        k_v = x_1 * v_1 / v_tot * k_1 + x_2 * v_2 / v_tot * k_2
-        k_r = v_tot / (x_1 * v_1 / k_1 + x_2 * v_2 / k_2)
-        return 0.5 * (k_v + k_r)
+        c_v = x_1 * v_1 / v_tot * c_1 + x_2 * v_2 / v_tot * c_2
+        c_r = v_tot / (x_1 * v_1 / c_1 + x_2 * v_2 / c_2)
+        return 0.5 * (c_v + c_r)
 
     def _k_feo_0_VRH_average(self, data, eta_ls):
         """Calculates the bulk modulus of FeO in Ferropericlase at ambient conditions.
@@ -239,8 +289,45 @@ class _EOS_fp(_EOS):
         Returns:
             Float64: Bulk modulus of FeO in Fp at ambient conditions. [GPa]
         """
-        return self._k_VRH_average(
+        return self._VRH_average(
             eta_ls, data.v_feo_ls_0, data.k_feo_ls_0, data.v_feo_hs_0, data.k_feo_hs_0
+        )
+
+    def _g_feo_0_VRH_average(self, data, eta_ls):
+        """Calculates the shear modulus of FeO in Ferropericlase at ambient conditions.
+
+        This function calculates the shear modulus of FeO at ambient conditions using
+        the Voigt-Reuss-Hill average. It is assumed that the FeO in Ferropericlase is a
+        mixture of FeO in a low spin state and FeO in a high spin state.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            eta_ls: Average proportion of FeO in the low spin state.
+
+        Returns:
+            Float64: Shear modulus of FeO in Fp at ambient conditions. [GPa]
+        """
+        return self._VRH_average(
+            eta_ls, data.v_feo_ls_0, data.g_feo_ls_0, data.v_feo_hs_0, data.g_feo_hs_0
+        )
+
+    def _g_prime_feo_VRH_average(self, data, eta_ls):
+        """Calculates the pressure derivative of the shear modulus for FeO in Fp.
+
+        This function calculates the pressure derivative of the shear modulus for FeO
+        using the Voigt-Reuss-Hill average. It is assumed that the FeO in Ferropericlase
+        is a mixture of FeO in a low spin state and FeO in a high spin state.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            eta_ls: Average proportion of FeO in the low spin state.
+
+        Returns:
+            Float64: Pressure derivative of the shear modulus for FeO in Fp.
+        """
+        return self._VRH_average(
+            eta_ls, data.v_feo_ls_0, data.g_prime_feo_ls, data.v_feo_hs_0,
+            data.g_prime_feo_hs
         )
 
     def _k_fp_0_VRH_average(self, data, eta_ls, x_fp):
@@ -261,8 +348,53 @@ class _EOS_fp(_EOS):
         v_feo_0 = self._v_feo_0(data, eta_ls)
         # Bulk modulus of FeO at ambient conditions
         k_feo_0 = self._k_feo_0_VRH_average(data, eta_ls)
-        return self._k_VRH_average(
+        return self._VRH_average(
             x_fp, v_feo_0, k_feo_0, data.v_mgo_0, data.k_mgo_0
+        )
+
+    def _g_fp_0_VRH_average(self, data, eta_ls, x_fp):
+        """Calculates the shear modulus of Ferropericlase at ambient conditions.
+
+        This function calculates the shear modulus of Fp at ambient conditions using
+        the Voigt-Reuss-Hill average. It is assumed that Fp is a mixture of FeO and MgO.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            eta_ls: Average proportion of FeO in the low spin state.
+            x_fp: Molar concentration of FeO in Fp.
+
+        Returns:
+            Float64: Shear modulus of Fp at ambient conditions. [GPa]
+        """
+        # Volume of FeO at ambient conditions
+        v_feo_0 = self._v_feo_0(data, eta_ls)
+        # Shear modulus of FeO at ambient conditions
+        g_feo_0 = self._g_feo_0_VRH_average(data, eta_ls)
+        return self._VRH_average(
+            x_fp, v_feo_0, g_feo_0, data.v_mgo_0, data.g_mgo_0
+        )
+
+    def _g_prime_fp_VRH_average(self, data, eta_ls, x_fp):
+        """Calculates the pressure derivative of the shear modulus for Ferropericlase.
+
+        This function calculates the pressure derivative of the shear modulus for Fp
+        using the Voigt-Reuss-Hill average. It is assumed that Fp is a mixture of FeO
+        and MgO.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            eta_ls: Average proportion of FeO in the low spin state.
+            x_fp: Molar concentration of FeO in Fp.
+
+        Returns:
+            Float64: Pressure derivative of the shear modulus for Fp.
+        """
+        # Volume of FeO at ambient conditions
+        v_feo_0 = self._v_feo_0(data, eta_ls)
+        # Pressure derivative of the shear modulus for FeO
+        g_prime_feo = self._g_prime_feo_VRH_average(data, eta_ls)
+        return self._VRH_average(
+            x_fp, v_feo_0, g_prime_feo, data.v_mgo_0, data.g_prime_mgo
         )
 
     def _gamma(self, data, v_ratio):
@@ -343,6 +475,32 @@ class _EOS_fp(_EOS):
         int_part_fp = super()._integral_vibrational_energy(theta_fp / T)
         return super()._E_th(2, data.R, T, theta_fp, int_part_fp)
 
+    def _E_th_dv(self, data, T, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0):
+        """
+        """
+        return super()._E_th_dv(
+            2, data.R, T, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0
+        )
+
+    def _E_th_dT(self, data, T, theta_fp, E_th_fp):
+        """
+        """
+        return super()._E_th_dT(2, data.R, T, theta_fp, E_th_fp)
+
+    def _alpha(self, data, T, k_fp_0, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0):
+        """
+        """
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_fp_dv = self._E_th_dv(
+            data, T, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0
+        )
+        # Partial derivative of the vibrational energy with respect to temperature
+        E_th_fp_dT = self._E_th_dT(data, T, theta_fp, E_th_fp)
+        return super()._alpha(
+            k_fp_0, gamma_fp, data.q_fp, v_fp, E_th_fp, E_th_fp_0, E_th_fp_dv,
+            E_th_fp_dT
+        )
+
     def _MGD(self, data, T, P, v_fp, eta_ls, x_fp):
         """Implements the Mie-Gruneisen-Debye EOS for Ferropericlase.
 
@@ -365,9 +523,9 @@ class _EOS_fp(_EOS):
         """
         # Bulk modulus of Fp at ambient conditions
         k_fp_0 = self._k_fp_0_VRH_average(data, eta_ls, x_fp)
-        # Calculate volume of Fp at ambient conditions
+        # Volume of Fp at ambient conditions
         v_fp_0 = self._v_fp_0(data, eta_ls, x_fp)
-        # Calculate volume ratio
+        # Volume ratio
         v_ratio = v_fp_0 / v_fp
         # Gruneisen parameter
         gamma_fp = self._gamma(data, v_ratio)
@@ -378,6 +536,58 @@ class _EOS_fp(_EOS):
         # Vibrational energy at ambient conditions
         E_th_fp_0 = self._E_th(data, 300, v_ratio)
         return super()._MGD(BM3_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0)
+
+    def _g_t0(self, data, v_fp, eta_ls, x_fp):
+        """
+        """
+        # Volume of Fp at ambient conditions
+        v_fp_0 = self._v_fp_0(data, eta_ls, x_fp)
+        # Volume ratio
+        v_ratio = v_fp_0 / v_fp
+        # Bulk modulus of Fp at ambient conditions
+        k_fp_0 = self._k_fp_0_VRH_average(data, eta_ls, x_fp)
+        # Shear modulus of Fp at ambient conditions
+        g_fp_0 = self._g_fp_0_VRH_average(data, eta_ls, x_fp)
+        # Pressure derivative of the shear modulus for Fp
+        g_prime_fp = self._g_prime_fp_VRH_average(data, eta_ls, x_fp)
+        return super()._g_t0(g_fp_0, g_prime_fp, k_fp_0, v_ratio)
+
+    def _g(self, data, T, v_fp, eta_ls, x_fp):
+        """
+        """
+        # Shear modulus at ambient temperature
+        g_fp_t0 = self._g_t0(data, v_fp, eta_ls, x_fp)
+        return g_fp_t0 + data.g_dot_fp * (T - 300)
+
+    def _k_s(self, data, T, v_fp, eta_ls, x_fp):
+        """
+        """
+        # Volume of Fp at ambient conditions
+        v_fp_0 = self._v_fp_0(data, eta_ls, x_fp)
+        # Volume ratio
+        v_ratio = v_fp_0 / v_fp
+        # Gruneisen parameter
+        gamma_fp = self._gamma(data, v_ratio)
+        # Debye temperature
+        theta_fp = self._theta(data, v_ratio)
+        # Bulk modulus of Fp at ambient conditions
+        k_fp_0 = self._k_fp_0_VRH_average(data, eta_ls, x_fp)
+        # Vibrational energy at T
+        E_th_fp = self._E_th(data, T, v_ratio)
+        # Vibrational energy at ambient conditions
+        E_th_fp_0 = self._E_th(data, 300, v_ratio)
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_fp_dv = self._E_th_dv(
+            data, T, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0
+        )
+        # Thermal expansion
+        alpha_fp = self._alpha(
+            data, T, k_fp_0, theta_fp, gamma_fp, v_fp, E_th_fp, E_th_fp_0
+        )
+        return super()._k_s(
+            T, k_fp_0, data.k0t_prime_fp, gamma_fp, data.q_fp, alpha_fp, v_fp, v_ratio,
+            E_th_fp, E_th_fp_0, E_th_fp_dv
+        )
 
 #======================================================================================#
 #                                                                                      #
@@ -391,7 +601,8 @@ class _EOS_bm(_EOS):
     functionality required to implement the Mie-Gruneisen-Debye equation of state.
 
     The formalism for the Mie-Gruneisen-Debye equation of state used in this class can
-    be found in Jackson and Rigden (1996).
+    be found in Jackson and Rigden (1996) while the shear modulus calculation can be
+    found in Bina and Helffrich (1992).
 
     This class should not be used outside the class MineralProperties.
     """
@@ -437,7 +648,7 @@ class _EOS_bm(_EOS):
             v_tot: Volume of Bm at ambient conditions. [cm^3/mol]
 
         Returns:
-            Float64: Bulk modulus of Fp at ambient conditions. [GPa]
+            Float64: Bulk modulus of Bm at ambient conditions. [GPa]
         """
         k_v = (
             x_mgsio3 * data.v_mgsio3_0 * data.k_mgsio3_0 +
@@ -454,6 +665,84 @@ class _EOS_bm(_EOS):
             x_fe2o3 * data.v_fe2o3_0 / data.k_fe2o3_0 
         )
         return 0.5 * (k_v + k_r)
+
+    def _g_bm_0_VRH_average(
+        self, data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_tot
+    ):
+        """Calculates the shear modulus of Bridgmanite at ambient conditions.
+
+        This function calculates the shear modulus of Bm at ambient conditions using
+        the Voigt-Reuss-Hill average. The Voigt-Reuss-Hill average is traditionally
+        used to calculate the elasticity of polycrystal from the elasticity of its
+        individual components. Here, it is assumed that Bm is a mixture of MgSiO3, 
+        FeSiO3, FeAlO3, Fe2O3, and Al2O3.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            x_mgsio3: Molar concentration of MgSiO3 in Bm.
+            x_fesio3: Molar concentration of FeSiO3 in Bm.
+            x_fealo3: Molar concentration of FeAlO3 in Bm.
+            x_fe2o3: Molar concentration of Fe2O3 in Bm.
+            x_al2o3: Molar concentration of Al2O3 in Bm.
+            v_tot: Volume of Bm at ambient conditions. [cm^3/mol]
+
+        Returns:
+            Float64: Shear modulus of Bm at ambient conditions. [GPa]
+        """
+        g_v = (
+            x_mgsio3 * data.v_mgsio3_0 * data.g_mgsio3_0 +
+            x_fesio3 * data.v_fesio3_0 * data.g_fesio3_0 +
+            x_fealo3 * data.v_fealo3_0 * data.g_fealo3_0 +
+            x_al2o3 * data.v_al2o3_0 * data.g_al2o3_0 +
+            x_fe2o3 * data.v_fe2o3_0 * data.g_fe2o3_0
+        ) / v_tot
+        g_r = v_tot / (
+            x_mgsio3 * data.v_mgsio3_0 / data.g_mgsio3_0 +
+            x_fesio3 * data.v_fesio3_0 / data.g_fesio3_0 +
+            x_fealo3 * data.v_fealo3_0 / data.g_fealo3_0 +
+            x_al2o3 * data.v_al2o3_0 / data.g_al2o3_0 +
+            x_fe2o3 * data.v_fe2o3_0 / data.g_fe2o3_0
+        )
+        return 0.5 * (g_v + g_r)
+
+    def _g_prime_bm_VRH_average(
+        self, data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_tot
+    ):
+        """Calculates the pressure derivative of the shear modulus for Bridgmanite.
+
+        This function calculates the pressure derivative of the shear modulus for Bm
+        using the Voigt-Reuss-Hill average. The Voigt-Reuss-Hill average is
+        traditionally used to calculate the elasticity of polycrystal from the
+        elasticity of its individual components. Here, it is assumed that Bm is a
+        mixture of MgSiO3, FeSiO3, FeAlO3, Fe2O3, and Al2O3.
+
+        Args:
+            data: Data holder for the MineralProperties class.
+            x_mgsio3: Molar concentration of MgSiO3 in Bm.
+            x_fesio3: Molar concentration of FeSiO3 in Bm.
+            x_fealo3: Molar concentration of FeAlO3 in Bm.
+            x_fe2o3: Molar concentration of Fe2O3 in Bm.
+            x_al2o3: Molar concentration of Al2O3 in Bm.
+            v_tot: Volume of Bm at ambient conditions. [cm^3/mol]
+
+        Returns:
+            Float64: Pressure derivative of the shear modulus for Bm.
+        """
+        g_prime_v = (
+            x_mgsio3 * data.v_mgsio3_0 * data.g_prime_mgsio3 +
+            x_fesio3 * data.v_fesio3_0 * data.g_prime_fesio3 +
+            x_fealo3 * data.v_fealo3_0 * data.g_prime_fealo3 +
+            x_al2o3 * data.v_al2o3_0 * data.g_prime_al2o3 +
+            x_fe2o3 * data.v_fe2o3_0 * data.g_prime_fe2o3
+        ) / v_tot
+        g_prime_r = v_tot / (
+            x_mgsio3 * data.v_mgsio3_0 / data.g_prime_mgsio3 +
+            x_fesio3 * data.v_fesio3_0 / data.g_prime_fesio3 +
+            x_fealo3 * data.v_fealo3_0 / data.g_prime_fealo3 +
+            x_al2o3 * data.v_al2o3_0 / data.g_prime_al2o3 +
+            x_fe2o3 * data.v_fe2o3_0 / data.g_prime_fe2o3
+        )
+        return 0.5 * (g_prime_v + g_prime_r)
 
     def _gamma(self, data, v_ratio):
         """Calculates the Gruneisen parameter of Bridgmanite.
@@ -535,6 +824,32 @@ class _EOS_bm(_EOS):
         int_part_bm = super()._integral_vibrational_energy(theta_bm / T)
         return super()._E_th(5, data.R, T, theta_bm, int_part_bm)
 
+    def _E_th_dv(self, data, T, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0):
+        """
+        """
+        return super()._E_th_dv(
+            5, data.R, T, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0
+        )
+
+    def _E_th_dT(self, data, T, theta_bm, E_th_bm):
+        """
+        """
+        return super()._E_th_dT(2, data.R, T, theta_bm, E_th_bm)
+
+    def _alpha(self, data, T, k_bm_0, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0):
+        """
+        """
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_bm_dv = self._E_th_dv(
+            data, T, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0
+        )
+        # Partial derivative of the vibrational energy with respect to temperature
+        E_th_bm_dT = self._E_th_dT(data, T, theta_bm, E_th_bm)
+        return super()._alpha(
+            k_bm_0, gamma_bm, data.q_bm, v_bm, E_th_bm, E_th_bm_0, E_th_bm_dv,
+            E_th_bm_dT
+        )
+
     def _MGD(self, data, T, P, v_bm, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3):
         """Implements the Mie-Gruneisen-Debye EOS for Bridgmanite.
 
@@ -558,9 +873,9 @@ class _EOS_bm(_EOS):
         Returns:
             Float64: Residue of the Mie-Gruneisen-Debye EOS for Bm. [GPa]
         """
-        # Calculate volume of Bm at ambient conditions
+        # Volume of Bm at ambient conditions
         v_bm_0 = self._v_bm_0(data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3)
-        # Calculate volume ratio
+        # Volume ratio
         v_ratio = v_bm_0 / v_bm
         # Bulk modulus of Bm at ambient conditions
         k_bm_0 = self._k_bm_0_VRH_average(
@@ -576,6 +891,66 @@ class _EOS_bm(_EOS):
         E_th_bm_0 = self._E_th(data, 300, v_ratio)
         return super()._MGD(BM3_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0)
 
+    def _g_t0(self, data, v_bm, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3):
+        """
+        """
+        # Volume of Bm at ambient conditions
+        v_bm_0 = self._v_bm_0(data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3)
+        # Volume ratio
+        v_ratio = v_bm_0 / v_bm
+        # Bulk modulus of Bm at ambient conditions
+        k_bm_0 = self._k_bm_0_VRH_average(
+            data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_bm_0
+        )
+        # Shear modulus of Bm at ambient conditions
+        g_bm_0 = self._g_bm_0_VRH_average(
+            data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_bm_0
+        )
+        # Pressure derivative of the shear modulus for Bm
+        g_prime_bm = self._g_prime_bm_VRH_average(
+            data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_bm_0
+        )
+        return super()._g_t0(g_bm_0, g_prime_bm, k_bm_0, v_ratio)
+
+    def _g(self, data, T, v_bm, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3):
+        """
+        """
+        # Shear modulus at ambient temperature
+        g_bm_t0 = self._g_t0(data, v_bm, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3)
+        return g_bm_t0 + data.g_dot_bm * (T - 300)
+
+    def _k_s(self, data, T, v_bm, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3):
+        """
+        """
+        # Volume of Bm at ambient conditions
+        v_bm_0 = self._v_bm_0(data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3)
+        # Volume ratio
+        v_ratio = v_bm_0 / v_bm
+        # Gruneisen parameter
+        gamma_bm = self._gamma(data, v_ratio)
+        # Debye temperature
+        theta_bm = self._theta(data, v_ratio)
+        # Bulk modulus of Bm at ambient conditions
+        k_bm_0 = self._k_bm_0_VRH_average(
+            data, x_mgsio3, x_fesio3, x_fealo3, x_fe2o3, x_al2o3, v_bm_0
+        )
+        # Vibrational energy at T
+        E_th_bm = self._E_th(data, T, v_ratio)
+        # Vibrational energy at ambient conditions
+        E_th_bm_0 = self._E_th(data, 300, v_ratio)
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_bm_dv = self._E_th_dv(
+            data, T, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0
+        )
+        # Thermal expansion
+        alpha_bm = self._alpha(
+            data, T, k_bm_0, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0
+        )
+        return super()._k_s(
+            T, k_bm_0, data.k0t_prime_bm, gamma_bm, data.q_bm, alpha_bm, v_bm, v_ratio,
+            E_th_bm, E_th_bm_0, E_th_bm_dv
+        )
+
 #======================================================================================#
 #                                                                                      #
 # Starting implementation of the class for calculation of Calcio Perovskite properties #
@@ -588,7 +963,8 @@ class _EOS_capv(_EOS):
     functionality required to implement the Mie-Gruneisen-Debye equation of state.
 
     The formalism for the Mie-Gruneisen-Debye equation of state used in this class can
-    be found in Jackson and Rigden (1996).
+    be found in Jackson and Rigden (1996) while the shear modulus calculation can be
+    found in Bina and Helffrich (1992).
 
     This class should not be used outside the class MineralProperties.
     """
@@ -666,7 +1042,7 @@ class _EOS_capv(_EOS):
                      conditions.
 
         Returns:
-            Float64: Vibrational energy of Bm at the considered conditions.
+            Float64: Vibrational energy of CaPv at the considered conditions.
                      [cm^3 GPa mol^−1]
         """
         # Debye temperature
@@ -674,6 +1050,34 @@ class _EOS_capv(_EOS):
         # Integral part of the vibrational energy
         int_part_capv = super()._integral_vibrational_energy(theta_capv / T)
         return super()._E_th(5, data.R, T, theta_capv, int_part_capv)
+
+    def _E_th_dv(self, data, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0):
+        """
+        """
+        return super()._E_th_dv(
+            5, data.R, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0
+        )
+
+    def _E_th_dT(self, data, T, theta_capv, E_th_capv):
+        """
+        """
+        return super()._E_th_dT(2, data.R, T, theta_capv, E_th_capv)
+
+    def _alpha(
+        self, data, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0
+    ):
+        """
+        """
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_capv_dv = self._E_th_dv(
+            data, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0
+        )
+        # Partial derivative of the vibrational energy with respect to temperature
+        E_th_capv_dT = self._E_th_dT(data, T, theta_capv, E_th_capv)
+        return super()._alpha(
+            data.k_casio3_0, gamma_capv, data.q_capv, v_capv, E_th_capv, E_th_capv_0,
+            E_th_capv_dv, E_th_capv_dT
+        )
 
     def _MGD(self, data, T, P, v_capv):
         """Implements the Mie-Gruneisen-Debye EOS for Calcio Perovskite.
@@ -693,7 +1097,7 @@ class _EOS_capv(_EOS):
         Returns:
             Float64: Residue of the Mie-Gruneisen-Debye EOS for CaPv. [GPa]
         """
-        # Calculate volume ratio
+        # Volume ratio
         v_ratio = data.v_casio3_0 / v_capv
         # Gruneisen parameter
         gamma_capv = self._gamma(data, v_ratio)
@@ -704,3 +1108,43 @@ class _EOS_capv(_EOS):
         # Vibrational energy at ambient conditions
         E_th_capv_0 = self._E_th(data, 300, v_ratio)
         return super()._MGD(BM3_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0)
+
+    def _g_t0(self, data, v_ratio):
+        """
+        """
+        return super()._g_t0(
+            data.g_casio3_0, data.g_prime_casio3, data.k_casio3_0, v_ratio
+        )
+
+    def _g(self, data, T, v_ratio):
+        """
+        """
+        # Shear modulus at ambient temperature
+        g_capv_t0 = self._g_t0(data, v_ratio)
+        return g_capv_t0 + data.g_dot_capv * (T - 300)
+
+    def _k_s(self, data, T, v_capv):
+        """
+        """
+        # Volume ratio
+        v_ratio = data.v_casio3_0 / v_capv
+        # Gruneisen parameter
+        gamma_capv = self._gamma(data, v_ratio)
+        # Debye temperature
+        theta_capv = self._theta(data, v_ratio)
+        # Vibrational energy at T
+        E_th_capv = self._E_th(data, T, v_ratio)
+        # Vibrational energy at ambient conditions
+        E_th_capv_0 = self._E_th(data, 300, v_ratio)
+        # Partial derivative of the vibrational energy with respect to volume
+        E_th_capv_dv = self._E_th_dv(
+            data, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0
+        )
+        # Thermal expansion
+        alpha_capv = self._alpha(
+            data, T, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0
+        )
+        return super()._k_s(
+            T, data.k_casio3_0, data.k0t_prime_capv, gamma_capv, data.q_capv,
+            alpha_capv, v_capv, v_ratio, E_th_capv, E_th_capv_0, E_th_capv_dv
+        )

--- a/src/_seismic_properties.py
+++ b/src/_seismic_properties.py
@@ -1,0 +1,34 @@
+"""
+
+This file is associated with the article:
+"Constraints on the composition and temperature of LLSVPs from seismic properties of
+lower mantle minerals" by K. Vilella, T. Bodin, C.-E. Boukare, F. Deschamps, J. Badro,
+M. D. Ballmer, and Y. Li
+
+These functions should not be used outside the class MineralProperties.
+
+Typical usage example:
+
+
+Copyright, 2023,  Vilella Kenny.
+"""
+import numpy as np
+from _eos_implementation import _EOS_fp, _EOS_bm, _EOS_capv
+#======================================================================================#
+#                                                                                      #
+#    Starting implementation of functions used to calculate the seismic properties     #
+#                                                                                      #
+#======================================================================================#
+def _calc_seismic_properties(self, spin_config, P_table):
+    """
+    """
+    # Loading utility class for mineral properties calculation
+    fp_eos = _EOS_fp() 
+    bm_eos = _EOS_bm()
+    capv_eos = _EOS_capv()
+
+
+def _calc_v_p(self, v_phi, v_s):
+    """
+    """
+    return np.sqrt(v_phi * v_phi + (4/3) * v_s * v_s)


### PR DESCRIPTION
# Description
- Added all material properties related to the shear modulus calculation
- Added all utility functions in `_eos_implementation` to calculate the seismic velocities
- Changed the VRH average functions to be more general
- Improved and corrected some docstring
- Added a very rough skeleton of `_seismic_properties.py`

# Note
Only some of the new functions docstring in `_eos_implementation`  have been implemented.
The remaining docstrings will be implemented later on.