### PR TITLE
Bugfix in seismic anomalies calculation

### DIFF
--- a/src/_eos_implementation.py
+++ b/src/_eos_implementation.py
@@ -1090,7 +1090,7 @@ class _EOS_bm(_EOS):
             Float64: Partial derivative of the vibrational energy with respect to
                      temperature for Bm. [cm^3 GPa mol^−1 K^-1]
         """
-        return super()._E_th_dT(2, data.R, T, theta_bm, E_th_bm)
+        return super()._E_th_dT(5, data.R, T, theta_bm, E_th_bm)
 
     def _alpha(
         self, data, T, k_v_bm, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0, E_th_bm_dv
@@ -1294,7 +1294,7 @@ class _EOS_bm(_EOS):
         )
         # Thermal expansion coefficient
         alpha_bm = self._alpha(
-            data, T, k_bm_0, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0, E_th_bm_dv
+            data, T, k_v_bm, theta_bm, gamma_bm, v_bm, E_th_bm, E_th_bm_0, E_th_bm_dv
         )
         return super()._k_s(T, k_t_bm, alpha_bm, gamma_bm)
 
@@ -1442,7 +1442,7 @@ class _EOS_capv(_EOS):
             Float64: Partial derivative of the vibrational energy with respect to
                      temperature for CaPv. [cm^3 GPa mol^−1 K^-1]
         """
-        return super()._E_th_dT(2, data.R, T, theta_capv, E_th_capv)
+        return super()._E_th_dT(5, data.R, T, theta_capv, E_th_capv)
 
     def _alpha(
         self, data, T, k_v_capv, theta_capv, gamma_capv, v_capv, E_th_capv, E_th_capv_0,

--- a/src/_mineral_composition.py
+++ b/src/_mineral_composition.py
@@ -114,7 +114,7 @@ def _calc_mineral_composition(self, spin_config, P_table):
         solution = scipy.optimize.fsolve(
             lambda x: capv_eos._MGD(self, self.T_am + dT, self.P_am, x), 30.
         )
-        rho_capv = self.rho_capv_0 * solution[0]
+        rho_capv = self.rho_capv_0 * self.v_casio3_0 / solution[0]
 
         # Initializing starting condition
         x_init = [0.3, 0.1, 0.1, 5000.0, 5000.0]

--- a/src/_seismic_anomalies.py
+++ b/src/_seismic_anomalies.py
@@ -89,7 +89,7 @@ def _calc_seismic_anomalies(self, spin_config, P_table):
     )
 
     for file in os.listdir(self.path):
-        if (not file.endswith(".csv")):
+        if (not file.endswith(".csv") or file.endswith("_processed.csv")):
             continue
         print("Starting to process file: `", file, "`")
 
@@ -123,7 +123,7 @@ def _calc_seismic_anomalies(self, spin_config, P_table):
 
                 if isclose(p_fp, 0.0, abs_tol=1e-4):
                     ### No Ferropericlase, changing density to avoid errors ###
-                    rho_fp = 1.0
+                    rho_fp = 5500.0
 
                 if (rho_bm == 0.0):
                     ### No results for this condition ###
@@ -208,7 +208,7 @@ def _calc_seismic_properties(
     solution = scipy.optimize.fsolve(
         lambda x: capv_eos._MGD(self, self.T_am + dT, self.P_am, x), 20.
     )
-    rho_capv = self.rho_capv_0 * solution[0]
+    rho_capv = self.rho_capv_0 * self.v_casio3_0 / solution[0]
 
     # Calculating the spin configuration
     index_x = np.argmin(np.abs(self.x_vec - x_feo_fp))
@@ -217,12 +217,12 @@ def _calc_seismic_properties(
     eta_ls = spin_config[index_T, index_P, index_x]
 
     # Calculating composition of Bridgmanite in term of components
-    al_excess = (feo * x_feo_bm < x_alo2_bm)
-    x_mgsio3 = 1 - x_alo2_bm - (2 - feo) * x_feo_bm
-    x_fesio3 = 2 * (1 - feo) * x_feo_bm
-    x_fealo3 = 2 * (1.0 - al_excess) * x_alo2_bm + 2 * al_excess * feo * x_feo_bm
-    x_fe2o3 = (1.0 - al_excess) * (feo * x_feo_bm - x_alo2_bm)
-    x_al2o3 = al_excess * (x_alo2_bm - feo * x_feo_bm)
+    al_excess = (ratio_fe * x_feo_bm < x_alo2_bm)
+    x_mgsio3 = 1 - x_alo2_bm - (2 - ratio_fe) * x_feo_bm
+    x_fesio3 = 2 * (1 - ratio_fe) * x_feo_bm
+    x_fealo3 = 2 * (1.0 - al_excess) * x_alo2_bm + 2 * al_excess * ratio_fe * x_feo_bm
+    x_fe2o3 = (1.0 - al_excess) * (ratio_fe * x_feo_bm - x_alo2_bm)
+    x_al2o3 = al_excess * (x_alo2_bm - ratio_fe * x_feo_bm)
 
     # Calculating molar mass of Fp and Bm
     m_fp = self.m_mgo * (1 - x_feo_fp) + self.m_feo * x_feo_fp


### PR DESCRIPTION
# Description
- Corrected number of atom in formula unit for calculation of `_E_th_dT` for Bm and CaPv
- Changed from `k_bm_0` to `k_v_bm` in calculation of alpha for Bm
- Corrected calculation of `rho_capv`
- Corrected processing of files in  `_calc_seismic_anomalies` to ignore already processed files
- Corrected dummy value for `rho_fp` when no Fp is present, otherwise it results to NaN value
- Changed from `feo` to `ratio_fe` in calculation of composition of Bridgmanite in term of components

# Note
The current calculation of the seismic properties were verified against the matlab version used in Vilella et al. (2021) so it should be correct.
They are however still issues with the calculation of the spin configuration and mineral composition.