### PR TITLE
Bugfix in _mineral_composition and _seismic_anomalies

### DIFF
--- a/src/_mineral_composition.py
+++ b/src/_mineral_composition.py
@@ -218,8 +218,8 @@ def _calc_mineral_composition(self, spin_config, P_table):
                             with open(filename, 'a', newline='') as csvfile:
                                 data_writer = csv.writer(csvfile, delimiter=' ')
                                 data_writer.writerow([
-                                    dT, p_capv, p_bm, feo, al, ratio_fe, x_init[0],
-                                    x_init[1], x_init[2], x_init[3], x_init[4]
+                                    dT, p_capv, p_bm, feo, al, ratio_fe, x_result[0],
+                                    x_result[1], x_result[2], x_result[3], x_result[4]
                                 ])
                             p_capv_ii[jj, kk, ll, mm, nn] = p_capv
                             p_bm_ii[jj, kk, ll, mm, nn] = p_bm

--- a/src/_seismic_anomalies.py
+++ b/src/_seismic_anomalies.py
@@ -69,7 +69,7 @@ def _calc_seismic_anomalies(self, spin_config, P_table):
     solution = scipy.optimize.fsolve(
         lambda x: capv_eos._MGD(self, self.T_am, self.P_am, x), 20.
     )
-    rho_capv_am = self.rho_capv_0 * solution[0]
+    rho_capv_am = self.rho_capv_0 * self.v_casio3_0 / solution[0]
 
     # Calculating the composition of the ambient mantle
     p_fp_am = 1 - self.p_capv_am - self.p_bm_am


### PR DESCRIPTION
# Description
- Corrected calculation of CaPv density for the ambient mantle in `_seismic_anomalies.py`
- Corrected that incorrect results were written into file in `_mineral_composition.py`

# Note
A general verification has been made against the matlab version and show somewhat reasonable agreement.
More testing should be done.