### PR TITLE
Bugfix add correct folder for doc deployment in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/html


### PR DESCRIPTION
# Description
- Added `publish_dir` in CI workflow