### PR TITLE
Bugfix correct token in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,5 @@ jobs:
       - name: Deploy the documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           folder: ./docs/build/html


### PR DESCRIPTION
# Description
- Changed from github_token to token in CI workflow